### PR TITLE
ENTERPRISE-706: Introduce an option to fail gracefully

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ Check [Injecting Secrets into Jenkins Build Jobs](https://support.cloudbees.com/
 
 ## Changelog
 
+* 1.1.3
+ * Introduce a configuration option to mark builds as UNSTABLE rather than FAILED if a remote CodeScene analysis couldn't be performed.
 * 1.1.2
   * Add Biomarkers support to auto-detect files that seem to degrade in quality through issues introduced in a changeset - requires CodeScene version 2.4.0 or higher.
 * 1.1.1

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>codescene</artifactId>
-    <version>1.1.3-SNAPSHOT</version>
+    <version>1.1.3</version>
     <packaging>hpi</packaging>
 
     <properties>

--- a/src/main/java/org/jenkinsci/plugins/codescene/CodeSceneBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/codescene/CodeSceneBuilder.java
@@ -181,7 +181,8 @@ public class CodeSceneBuilder extends Builder implements SimpleBuildStep {
         return commitSets;
     }
 
-    private ArrayList<CodeSceneBuildActionEntry> runDeltaAnalysesOnIndividualCommits(Configuration config, List<String> revisions, TaskListener listener) throws MalformedURLException {
+    private ArrayList<CodeSceneBuildActionEntry> runDeltaAnalysesOnIndividualCommits(Configuration config, List<String> revisions, TaskListener listener)
+            throws RemoteAnalysisException, MalformedURLException {
         List<Commits> commitSets = revisionsAsIndividualCommitSets(revisions);
         ArrayList<CodeSceneBuildActionEntry> entries = new ArrayList<>(commitSets.size());
 
@@ -214,7 +215,8 @@ public class CodeSceneBuilder extends Builder implements SimpleBuildStep {
         return entries;
     }
 
-    private CodeSceneBuildActionEntry runDeltaAnalysisOnBranchDiff(Configuration config, List<String> revisions, String branchName, TaskListener listener) throws MalformedURLException {
+    private CodeSceneBuildActionEntry runDeltaAnalysisOnBranchDiff(Configuration config, List<String> revisions, String branchName, TaskListener listener)
+            throws RemoteAnalysisException, MalformedURLException {
         Commits commitSet = revisionsAsCommitSet(revisions);
         DeltaAnalysis deltaAnalysis = new DeltaAnalysis(config);
         listener.getLogger().format("Running delta analysis on branch %s in repository %s.%n", branchName, config.gitRepisitoryToAnalyze().value());
@@ -270,6 +272,9 @@ public class CodeSceneBuilder extends Builder implements SimpleBuildStep {
                 }
             }
 
+        } catch (RemoteAnalysisException e) {
+            listener.error("Remote failure as CodeScene couldn't perform the delta analysis: %s", e);
+            build.setResult(Result.UNSTABLE);
         } catch (InterruptedException | IOException e) {
             listener.error("Failed to run delta analysis: %s", e);
             build.setResult(Result.FAILURE);

--- a/src/main/java/org/jenkinsci/plugins/codescene/CodeSceneBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/codescene/CodeSceneBuilder.java
@@ -65,6 +65,9 @@ public class CodeSceneBuilder extends Builder implements SimpleBuildStep {
     private int couplingThresholdPercent = DEFAULT_COUPLING_THRESHOLD_PERCENT;
     // CodeScene 2.4.0+ supports biomarkers as a separate risk category - default: true
     private boolean useBiomarkers = true;
+    // Some users prefer their builds to continue even if CodeScene -- for some reason -- fail to
+    // execute the delta analysis. By default we fail the build, but this can be overriden:
+    private boolean failBuildOnFailedAnalysis = true;
 
     // deprecated authentication params - use credentialsId instead
     @Deprecated private transient String username;
@@ -119,6 +122,10 @@ public class CodeSceneBuilder extends Builder implements SimpleBuildStep {
         return useBiomarkers;
     }
 
+    public boolean isFailBuildOnFailedAnalysis() {
+        return failBuildOnFailedAnalysis;
+    }
+
     @DataBoundSetter
     public void setAnalyzeLatestIndividually(boolean analyzeLatestIndividually) {
         this.analyzeLatestIndividually = analyzeLatestIndividually;
@@ -155,6 +162,9 @@ public class CodeSceneBuilder extends Builder implements SimpleBuildStep {
     public void setUseBiomarkers(boolean useBiomarkers) {
         this.useBiomarkers = useBiomarkers;
     }
+
+    @DataBoundSetter
+    public void setFailBuildOnFailedAnalysis(boolean failBuildOnFailedAnalysis) { this.failBuildOnFailedAnalysis = failBuildOnFailedAnalysis; }
 
     // handle default values for new fields with regards to existing jobs (backward compatibility)
     // check https://wiki.jenkins-ci.org/display/JENKINS/Hint+on+retaining+backward+compatibility
@@ -241,7 +251,7 @@ public class CodeSceneBuilder extends Builder implements SimpleBuildStep {
             URL url = new URL(deltaAnalysisUrl);
 
             Configuration codesceneConfig = new Configuration(url, userConfig(), new Repository(repository),
-                    couplingThresholdPercent, useBiomarkers);
+                    couplingThresholdPercent, useBiomarkers, failBuildOnFailedAnalysis);
             EnvVars env = build.getEnvironment(listener);
 
             String previousCommit = env.get("GIT_PREVIOUS_SUCCESSFUL_COMMIT");
@@ -274,11 +284,19 @@ public class CodeSceneBuilder extends Builder implements SimpleBuildStep {
 
         } catch (RemoteAnalysisException e) {
             listener.error("Remote failure as CodeScene couldn't perform the delta analysis: %s", e);
-            build.setResult(Result.UNSTABLE);
+            build.setResult(buildResultDependsOn(failBuildOnFailedAnalysis));
         } catch (InterruptedException | IOException e) {
             listener.error("Failed to run delta analysis: %s", e);
             build.setResult(Result.FAILURE);
         }
+    }
+
+    private static Result buildResultDependsOn(final boolean failOnFailedAnalysis) {
+        if (failOnFailedAnalysis) {
+            return Result.FAILURE;
+        }
+
+        return Result.UNSTABLE;
     }
 
     private CodeSceneUser userConfig() {

--- a/src/main/java/org/jenkinsci/plugins/codescene/Domain/Configuration.java
+++ b/src/main/java/org/jenkinsci/plugins/codescene/Domain/Configuration.java
@@ -9,14 +9,17 @@ public class Configuration {
     private final Repository repo;
     private final int couplingThresholdPercent;
     private final boolean useBiomarkers;
+    private final boolean failBuildOnFailedAnalysis;
 
     public Configuration(final URL codeSceneUrl, final CodeSceneUser user, final Repository gitRepositoryToAnalyze,
-                         int couplingThresholdPercent, boolean useBiomarkers) {
+                         int couplingThresholdPercent, boolean useBiomarkers,
+                         boolean failBuildOnFailedAnalysis) {
         this.url = codeSceneUrl;
         this.user = user;
         this.repo = gitRepositoryToAnalyze;
         this.couplingThresholdPercent = couplingThresholdPercent;
         this.useBiomarkers = useBiomarkers;
+        this.failBuildOnFailedAnalysis = failBuildOnFailedAnalysis;
     }
 
     public URL codeSceneUrl() {
@@ -38,4 +41,6 @@ public class Configuration {
     public boolean useBiomarkers() {
         return useBiomarkers;
     }
+
+    public boolean failBuildOnFailedAnalysis() { return failBuildOnFailedAnalysis; }
 }

--- a/src/main/java/org/jenkinsci/plugins/codescene/Domain/RemoteAnalysisException.java
+++ b/src/main/java/org/jenkinsci/plugins/codescene/Domain/RemoteAnalysisException.java
@@ -1,0 +1,17 @@
+package org.jenkinsci.plugins.codescene.Domain;
+
+/**
+ * A custom exception in case the remote CodeScene analysis failed.
+ * We need a separate error handling in this case since some users
+ * do not want to fail their whole build pipeline.
+ */
+public class RemoteAnalysisException extends Exception {
+
+    public RemoteAnalysisException(final String rootCause) {
+        super(rootCause);
+    }
+
+    public RemoteAnalysisException(final String rootCause, final Exception rootException) {
+        super(rootCause, rootException);
+    }
+}

--- a/src/main/resources/org/jenkinsci/plugins/codescene/CodeSceneBuilder/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/codescene/CodeSceneBuilder/config.jelly
@@ -27,6 +27,9 @@
         <f:optionalBlock field="useBiomarkers" title="Use Biomarkers" inline="true" default="true" checked="${it.useBiomarkers}">
         </f:optionalBlock>
 
+        <f:optionalBlock field="failBuildOnFailedAnalysis" title="Fail Build on Failed Analysis" inline="true" default="true" checked="${it.failBuildOnFailedAnalysis}">
+        </f:optionalBlock>
+
         
     </f:section>
 

--- a/src/main/resources/org/jenkinsci/plugins/codescene/CodeSceneBuilder/help-failBuildOnFailedAnalysis.html
+++ b/src/main/resources/org/jenkinsci/plugins/codescene/CodeSceneBuilder/help-failBuildOnFailedAnalysis.html
@@ -1,0 +1,4 @@
+<div>
+    By default we fail the build if CodeScene couldn't run an analysis (e.g. couldn't update the repository).
+    This behaviour can be overridden here. If you uncheck this option, the plugin will mark the build as UNSTABLE instead.
+</div>


### PR DESCRIPTION
By default the plugin fails the build if CodeScene couldn't run an analysis (e.g. couldn't update the repository). This pull requests introduces the option to override this behaviour through a configuration option. If you uncheck the option to fail the build if the analysis fails, then the plugin will mark the build as UNSTABLE instead.