### PR TITLE
ENTERPRISE-728: Use base revision if no previous successful commit is available.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/codescene/Domain/Commit.java
+++ b/src/main/java/org/jenkinsci/plugins/codescene/Domain/Commit.java
@@ -12,7 +12,7 @@ public class Commit {
 
     public Commit(final String hash) {
         if (hash == null) {
-            throw new IllegalArgumentException("A commit hash cannot be null - just don't do that");
+            throw new IllegalArgumentException("A commit hash cannot be null!");
         }
 
         final Matcher m = hashPattern.matcher(hash);


### PR DESCRIPTION

This was a problem when the build was first run for a new branch without any previous OK build.
In that case, the "GIT_PREVIOUS_SUCCESSFUL_COMMIT" env variable was set to null,
which lead to an exception in the Commit class constructor and early job termination.
See also: https://issues.jenkins-ci.org/browse/JENKINS-51324

The issue was introduced by recent refactoring (using Commit domain class instead of pure Strings).
However, even the former solution (with Strings) seems to be suboptimal,
because in that case following git command was used to get commit range:
```
git log --pretty='%%H' ..<current_commit_sha>"
```
, which lead to an empty commit range.

Stacktrace from the error report:
```
ERROR: Build step failed with exception
java.lang.IllegalArgumentException: A commit hash cannot be null - just don't do that
        at org.jenkinsci.plugins.codescene.Domain.Commit.<init>(Commit.java:15)
        at org.jenkinsci.plugins.codescene.CodeSceneBuilder.perform(CodeSceneBuilder.java:266)
        at hudson.tasks.BuildStepCompatibilityLayer.perform(BuildStepCompatibilityLayer.java:81)
        at hudson.tasks.BuildStepMonitor$1.perform(BuildStepMonitor.java:20)
        at hudson.model.AbstractBuild$AbstractBuildExecution.perform(AbstractBuild.java:744)
        at hudson.model.Build$BuildExecution.build(Build.java:206)
        at hudson.model.Build$BuildExecution.doRun(Build.java:163)
        at hudson.model.AbstractBuild$AbstractBuildExecution.run(AbstractBuild.java:504)
        at hudson.model.Run.execute(Run.java:1798)
        at hudson.model.FreeStyleBuild.run(FreeStyleBuild.java:43)
        at hudson.model.ResourceController.execute(ResourceController.java:97)
        at hudson.model.Executor.run(Executor.java:429)
```