### PR TITLE
Switch to new parent plugin version to fix issue with findbugs-maven-plugin 3.0.3 (new version uses 3.0.4)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.11</version>
+        <version>2.25</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION


The findbugs plugin error was this (when trying to do `mvn release:prepare`):
```
    [INFO] --- findbugs-maven-plugin:3.0.3:findbugs (findbugs) @ codescene ---
    [INFO] ------------------------------------------------------------------------
    [INFO] BUILD FAILURE
    [INFO] ------------------------------------------------------------------------
    [INFO] Total time:  41.095 s
    [INFO] Finished at: 2019-03-25T10:13:10+01:00
    [INFO] ------------------------------------------------------------------------
    [ERROR] Failed to execute goal org.codehaus.mojo:findbugs-maven-plugin:3.0.3:findbugs (findbugs) on project codescene: Unable to parse configuration of mojo org.codehaus.mojo:findbugs-maven-plugin:3.0.3:findbugs for parameter pluginArtifacts: Cannot assign configuration entry 'pluginArtifacts' with value '${plugin.artifacts}' of type java.util.Collections.UnmodifiableRandomAccessList to property of type java.util.ArrayList -> [Help 1]

```

See also http://maven.40175.n5.nabble.com/3-4-0-SNAPSHOT-failure-with-findbugs-Re-colorized-Maven-output-td5871591.html