### PR TITLE
Update junit to 4.13.1 to fix temporary folder disclosure vulnerability.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>4.13.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
See https://github.com/jenkinsci/codescene-plugin/network/alert/pom.xml/junit:junit/open.
It's not important in our case but good to clear list of alerts of GitHub's dependabot.

Here's a copy of the `Impact` section from the bug description:
---
On Unix like systems, the system's temporary directory is shared between all users on that system. Because of this, when files and directories are written into this directory they are, by default, readable by other users on that same system.

This vulnerability does not allow other users to overwrite the contents of these directories or files. This is purely an information disclosure vulnerability.

When analyzing the impact of this vulnerability, here are the important questions to ask:

Do the JUnit tests write sensitive information, like API keys or passwords, into the temporary folder?
If yes, this vulnerability impacts you, but only if you also answer 'yes' to question 2.
If no, this vulnerability does not impact you.
Do the JUnit tests ever execute in an environment where the OS has other untrusted users.
This may apply in CI/CD environments but normally won't be 'yes' for personal developer machines.
If yes, and you answered 'yes' to question 1, this vulnerability impacts you.
If no, this vulnerability does not impact you.