### PR TITLE
fix issue #24 by throwing an exception to signal stage on failure

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/codescene/DeltaAnalysis.java
+++ b/src/main/java/org/jenkinsci/plugins/codescene/DeltaAnalysis.java
@@ -24,16 +24,13 @@ public class DeltaAnalysis {
         this.config = config;
     }
 
-    public DeltaAnalysisResult runOn(final Commits commits) throws RemoteAnalysisException {
+    public DeltaAnalysisResult runOn(final Commits commits) throws RemoteAnalysisException, IOException {
         final DeltaAnalysisRequest payload = new DeltaAnalysisRequest(commits, config);
 
         try {
             return synchronousRequestWith(payload, commits);
         } catch (URISyntaxException e) {
             throw new IllegalArgumentException("The configured CodeScene URL isn't valid", e);
-        } catch (IOException e) {
-            throw new RemoteAnalysisException("Failed to send request to CodeScene at " + config.codeSceneUrl().toString()
-                    + "\n  cause: " + e.getMessage(), e);
         }
     }
 

--- a/src/main/java/org/jenkinsci/plugins/codescene/DeltaAnalysis.java
+++ b/src/main/java/org/jenkinsci/plugins/codescene/DeltaAnalysis.java
@@ -24,6 +24,13 @@ public class DeltaAnalysis {
         this.config = config;
     }
 
+    /**
+     * run the delta analysis for the given Commits
+     * @param commits the list of commits encapsulated in the {@link Commits} object
+     * @return a {@link DeltaAnalysisResult} object
+     * @throws RemoteAnalysisException - in case of delta analyses failure reported by codecene instance
+     * @throws IOException - in case of IO problems (ex: codescene instance not reachable)
+     */
     public DeltaAnalysisResult runOn(final Commits commits) throws RemoteAnalysisException, IOException {
         final DeltaAnalysisRequest payload = new DeltaAnalysisRequest(commits, config);
 


### PR DESCRIPTION
Fixes https://github.com/jenkinsci/codescene-plugin/issues/24

![image](https://user-images.githubusercontent.com/1083629/125558562-f566c7fc-083f-4d05-bfbb-eee287cf47a9.png)


<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

By looking in the `error` step https://www.jenkins.io/doc/pipeline/steps/workflow-basic-steps/#error-error-signal source code https://github.com/vfarcic/workflow-plugin/blob/master/basic-steps/src/main/java/org/jenkinsci/plugins/workflow/steps/ErrorStep.java I see that the signalling is done by throwing an AbortException.

We cannot throw AbortException, which is checked exception, because CodeScene plugin is developed to run as a standalone build as well but I can throw a RuntimeException to achieve same result. See the image above.

Also IOException is not affected by the flag `letBuildPassOnFailedAnalysis`
 